### PR TITLE
Handle catalogue items without icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build/
 local.properties
 .settings/
 .loadpath
+brooklyn.*.log*
 
 # Eclipse Core
 .project

--- a/src/main/java/org/cloudfoundry/community/servicebroker/brooklyn/service/BrooklynRestAdmin.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/brooklyn/service/BrooklynRestAdmin.java
@@ -22,6 +22,7 @@ import org.apache.brooklyn.rest.domain.SensorSummary;
 import org.apache.brooklyn.rest.domain.TaskSummary;
 import org.apache.brooklyn.util.core.http.HttpTool;
 import org.apache.brooklyn.util.core.http.HttpToolResponse;
+import org.apache.brooklyn.util.text.Strings;
 import org.apache.http.client.HttpClient;
 import org.cloudfoundry.community.servicebroker.brooklyn.config.BrooklynConfig;
 import org.cloudfoundry.community.servicebroker.brooklyn.repository.Repositories;
@@ -308,12 +309,13 @@ public class BrooklynRestAdmin {
 			return new AsyncResult<>(null);
 		}
 	}
-	
+
 	@Async
 	public Future<String> getIconAsBase64(String url){
+		if (Strings.isEmpty(url)) return new AsyncResult<>(null);
 		try {
 			HttpToolResponse response = HttpTool.httpGet(httpClient, new URI(config.toFullUrl(url)), Collections.<String, String>emptyMap());
-			return new AsyncResult<>("data:img/png;base64," + BaseEncoding.base64().encode(response.getContent())); 
+			return new AsyncResult<>("data:img/png;base64," + BaseEncoding.base64().encode(response.getContent()));
 		} catch (Exception e) {
 			LOG.error("unable to encode icon as base64");
 			return new AsyncResult<>(null);

--- a/src/main/java/org/cloudfoundry/community/servicebroker/brooklyn/service/plan/AbstractCatalogPlanStrategy.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/brooklyn/service/plan/AbstractCatalogPlanStrategy.java
@@ -12,6 +12,7 @@ import java.util.concurrent.Future;
 
 import org.apache.brooklyn.rest.domain.CatalogItemSummary;
 import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.yaml.Yamls;
 import org.cloudfoundry.community.servicebroker.brooklyn.config.BrooklynConfig;
 import org.cloudfoundry.community.servicebroker.brooklyn.service.BrooklynRestAdmin;
@@ -81,12 +82,15 @@ public abstract class AbstractCatalogPlanStrategy implements CatalogPlanStrategy
 				} catch(Exception e) {
 					LOG.error("unable to make plans: Unexpected blueprint format");
 				}
-				if (plans.size() == 0) {
+				if (plans.isEmpty()) {
 					continue;
 				}
 				List<String> tags = getTags();
-				Future<String> iconAsBase64Future = admin.getIconAsBase64(app.getIconUrl());
-				String iconUrl = ServiceUtil.getFutureValueLoggingError(iconAsBase64Future);
+				String iconUrl = null;
+				if (!Strings.isEmpty(app.getIconUrl())) {
+					Future<String> iconAsBase64Future = admin.getIconAsBase64(app.getIconUrl());
+					iconUrl = ServiceUtil.getFutureValueLoggingError(iconAsBase64Future);
+				}
 				Map<String, Object> metadata = getServiceDefinitionMetadata(iconUrl, app.getPlanYaml());
 				List<String> requires = getTags();
 				DashboardClient dashboardClient = null;
@@ -133,7 +137,7 @@ public abstract class AbstractCatalogPlanStrategy implements CatalogPlanStrategy
 
 	private Map<String, Object> getServiceDefinitionMetadata(String iconUrl, String planYaml) {
 		Map<String, Object> metadata = new HashMap<>();
-		metadata.put("imageUrl", iconUrl);
+        if (iconUrl != null) metadata.put("imageUrl", iconUrl);
         metadata.put("planYaml", planYaml);
 		return metadata;
 	}

--- a/src/test/java/org/cloudfoundry/community/servicebroker/brooklyn/service/plan/AbstractCatalogPlanStrategyTest.java
+++ b/src/test/java/org/cloudfoundry/community/servicebroker/brooklyn/service/plan/AbstractCatalogPlanStrategyTest.java
@@ -1,6 +1,9 @@
 package org.cloudfoundry.community.servicebroker.brooklyn.service.plan;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -46,6 +49,7 @@ public class AbstractCatalogPlanStrategyTest {
         List<ServiceDefinition> serviceDefinitions = catalogPlanStrategy.makeServiceDefinitions();
         assertEquals(1, serviceDefinitions.size());
         assertEquals("1.1", serviceDefinitions.get(0).getDescription());
+        verify(admin, never()).getIconAsBase64(anyString());
     }
 
     @Test
@@ -54,5 +58,6 @@ public class AbstractCatalogPlanStrategyTest {
         when(brooklynConfig.includesAllCatalogVersions()).thenReturn(true);
         List<ServiceDefinition> serviceDefinitions = catalogPlanStrategy.makeServiceDefinitions();
         assertEquals(2, serviceDefinitions.size());
+        verify(admin, never()).getIconAsBase64(anyString());
     }
 }


### PR DESCRIPTION
Previously the broker would request `/null`.